### PR TITLE
Added a softDelete button

### DIFF
--- a/packages/lesswrong/components/comments/CommentsList.jsx
+++ b/packages/lesswrong/components/comments/CommentsList.jsx
@@ -1,13 +1,21 @@
-import { Components, replaceComponent } from 'meteor/vulcan:core';
+import { Components, replaceComponent, withEdit } from 'meteor/vulcan:core';
 import React from 'react';
 import { FormattedMessage } from 'meteor/vulcan:i18n';
+import { Comments } from "meteor/example-forum";
 
-const CommentsList = ({comments, currentUser, highlightDate}) => {
+const CommentsList = ({comments, currentUser, highlightDate, editMutation}) => {
   if (comments) {
     return (
       <div className="comments-list">
-        {comments.map(comment => <Components.CommentsNode currentUser={currentUser} comment={comment} key={comment._id} newComment={highlightDate && (new Date(comment.postedAt).getTime() > new Date(highlightDate).getTime())}/>)}
-        {/*hasMore ? (ready ? <Components.CommentsLoadMore loadMore={loadMore} count={count} totalCount={totalCount} /> : <Components.Loading/>) : null*/}
+        {comments.map(comment =>
+          <Components.CommentsNode
+            currentUser={currentUser}
+            comment={comment}
+            key={comment._id}
+            newComment={highlightDate && (new Date(comment.postedAt).getTime() > new Date(highlightDate).getTime())}
+            editMutation={editMutation}
+            />)
+        }
       </div>
     )
   } else {
@@ -24,4 +32,10 @@ const CommentsList = ({comments, currentUser, highlightDate}) => {
 
 CommentsList.displayName = "CommentsList";
 
-replaceComponent('CommentsList', CommentsList);
+const withEditOptions = {
+  collection: Comments,
+  fragmentName: 'CommentsList',
+};
+
+
+replaceComponent('CommentsList', CommentsList, [withEdit, withEditOptions]);

--- a/packages/lesswrong/components/comments/CommentsNode.jsx
+++ b/packages/lesswrong/components/comments/CommentsNode.jsx
@@ -2,13 +2,24 @@ import { Components, replaceComponent } from 'meteor/vulcan:core';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-const CommentsNode = ({ comment, currentUser, newComment }) =>
+const CommentsNode = ({ comment, currentUser, newComment, editMutation}) =>
   <div className={newComment ? "comment-new" : "comment-old"}>
     <div className={"comments-node"}>
-      <Components.CommentsItem currentUser={currentUser} comment={comment} key={comment._id} />
+      <Components.CommentsItem
+        currentUser={currentUser}
+        comment={comment}
+        key={comment._id}
+        editMutation={editMutation}
+      />
       {comment.childrenResults ?
         <div className="comments-children">
-          {comment.childrenResults.map(comment => <CommentsNode currentUser={currentUser} comment={comment} key={comment._id} newComment={newComment} />)}
+          {comment.childrenResults.map(comment =>
+            <CommentsNode currentUser={currentUser}
+              comment={comment}
+              key={comment._id}
+              newComment={newComment}
+              editMutation={editMutation}
+            />)}
         </div>
         : null
       }

--- a/packages/lesswrong/components/comments/CommentsViews.jsx
+++ b/packages/lesswrong/components/comments/CommentsViews.jsx
@@ -8,7 +8,6 @@ import { withRouter } from 'react-router'
 import Users from 'meteor/vulcan:users';
 
 
-
 const viewNames = {
   'postCommentsTop': 'magical algorithm',
   'postCommentsNew': 'most recent',
@@ -63,10 +62,10 @@ class CommentsViews extends Component {
     let views = ["postCommentsTop", "postCommentsNew", "postCommentsBest"];
     const adminViews = ["postCommentsDeleted", "postCommentsSpam", "postCommentsReported"];
 
-    const currentQuery = (!_.isEmpty(router.location.query) && router.location.query) ||  {view: 'postCommentsTop', limit: 50};
+    const currentQuery = (!_.isEmpty(router.location.query) && router.location.query) ||  {view: 'postCommentsTop'};
     const currentLocation = router.location;
 
-    if (Users.canDo(props.currentUser, "comments.edit.all")) {
+    if (Users.canDo(props.currentUser, "comments.softRemove.all")) {
       views = views.concat(adminViews);
     }
     return (
@@ -112,4 +111,4 @@ CommentsViews.contextTypes = {
 
 CommentsViews.displayName = "PostsViews";
 
-registerComponent('CommentsViews', CommentsViews, withRouter);
+registerComponent('CommentsViews', CommentsViews, withRouter, withCurrentUser);

--- a/packages/lesswrong/lib/collections/comments/callbacks.js
+++ b/packages/lesswrong/lib/collections/comments/callbacks.js
@@ -1,0 +1,21 @@
+import { Comments } from "meteor/example-forum";
+import { addCallback, editMutation, runCallbacks } from 'meteor/vulcan:core';
+
+
+// function commentsSoftRemoveChildrenComments(comment) {
+//     const childrenComments = Comments.find({parentCommentId: comment._id}).fetch();
+//     childrenComments.forEach(childComment => {
+//       editMutation({
+//         documentId: childComment._id,
+//         set: {deleted:true},
+//         unset: {}
+//       }).then(()=>console.log('comment softRemoved')).catch(/* error */);
+//     });
+// }
+
+function CommentsEditSoftDeleteCallback (comment, oldComment) {
+  if (comment.deleted && !oldComment.deleted) {
+    runCallbacksAsync('comments.softDelete.async', comment);
+  }
+}
+addCallback("comments.edit.async", CommentsEditSoftDeleteCallback);

--- a/packages/lesswrong/lib/collections/comments/permissions.js
+++ b/packages/lesswrong/lib/collections/comments/permissions.js
@@ -1,0 +1,7 @@
+import Users from 'meteor/vulcan:users';
+import { Comments } from "meteor/example-forum";
+
+const sunshineRegimentActions = [
+  'notifications.softRemove.all',
+];
+Users.groups.sunshineRegiment.can(sunshineRegimentActions);

--- a/packages/lesswrong/lib/modules/fragments.js
+++ b/packages/lesswrong/lib/modules/fragments.js
@@ -160,6 +160,7 @@ registerFragment(`
     # example-forum
     _id
     postId
+    deleted
     parentCommentId
     topLevelCommentId
     body

--- a/packages/lesswrong/lib/modules/permissions.js
+++ b/packages/lesswrong/lib/modules/permissions.js
@@ -1,3 +1,3 @@
 import Users from 'meteor/vulcan:users';
 
-Users.createGroup("sunshine_regiment");
+Users.createGroup("sunshineRegiment");

--- a/packages/lesswrong/lib/views.js
+++ b/packages/lesswrong/lib/views.js
@@ -2,42 +2,64 @@ import { Comments } from 'meteor/example-forum';
 import Users from "meteor/vulcan:users";
 import LWEvents from "./collections/lwevents/collection.js";
 
-Comments.addView("postCommentsTop", function (terms) {
+// Comments.addDefaultView(function (terms) {
+//   return {
+//     selector: {deleted: {$ne: true}}
+//   };
+// });
+
+// TODO Please change this to "default view ignores deleted"
+
+Comments.addView("postCommentsDeleted", function (terms) {
   return {
     selector: {postId: terms.postId},
+    options: {sort: {deleted:-1}}
+  };
+});
+
+Comments.addView("postCommentsTop", function (terms) {
+  return {
+    selector: { postId: terms.postId, deleted: {$ne:true}},
     options: {sort: {baseScore: -1, postedAt: -1}}
   };
 });
 
 Comments.addView("postCommentsNew", function (terms) {
   return {
-    selector: {postId: terms.postId},
+    selector: { postId: terms.postId, deleted: {$ne:true}},
     options: {sort: {postedAt: -1}}
   };
 });
 
 Comments.addView("postCommentsBest", function (terms) {
   return {
-    selector: {postId: terms.postId},
+    selector: { postId: terms.postId, deleted: {$ne:true}},
     options: {sort: {baseScore: -1}, postedAt: -1}
   };
 });
 
 Comments.addView("recentComments", function (terms) {
   return {
+    selector: { deleted:{$ne:true}},
     options: {sort: {postedAt: -1}, limit: terms.limit || 5},
   };
 });
 
 Users.addView("topContributors", function (terms) {
   return {
+    selector: { deleted: {$ne:true}},
     options: {sort: {karma: -1}, limit: 5},
   };
 });
 
 LWEvents.addView("postVisits", function (terms) {
   return {
-    selector: {documentId: terms.postId, userId: terms.userId, name: "post-view"},
+    selector: {
+      documentId: terms.postId,
+      userId: terms.userId,
+      name: "post-view",
+      deleted: {$ne:true}
+    },
     options: {sort: {createdAt: -1}, limit: terms.limit || 1},
   };
 });

--- a/packages/lesswrong/styles/_colors.scss
+++ b/packages/lesswrong/styles/_colors.scss
@@ -1,6 +1,6 @@
 $light-yellow: #FFFBDB;
 
-$lightest-grey: #f3f3f3;
+$lightest-grey: #f0f0f0;
 $lighter-grey: #eee;
 $light-grey: #ddd;
 

--- a/packages/lesswrong/styles/_comments.scss
+++ b/packages/lesswrong/styles/_comments.scss
@@ -44,6 +44,13 @@
     opacity: 1;
   }
 }
+.comments-item.deleted {
+  background-color: #ffefef;
+  padding: $vmargin $hmargin;
+  .comments-item-text.content-body {
+    text-decoration: line-through;
+  }
+}
 
 .recent-comments-item {
   .recent-comments-item-meta {
@@ -78,6 +85,8 @@
 
 .comments-item-meta{
   margin-bottom: $vmargin;
+  border-bottom:solid 1px $lighter-border;
+  padding:5px 0;
   color: rgba(0,0,0,0.5);
   & > div {
     margin-right: 5px;


### PR DESCRIPTION
 • CommentsItem has handleDelete function
 • CommentsItem check for Users.canDo softRemove.all
 • CommentsItem displays Delete or Undo Delete button

 • CommentsList wrapped in withEdit
 • CommentsList passes editMutation into CommentsNode

 • CommentsNode passes editMutation to children

 • CommentsViews displays Admin views if admin has softRemove access

 • permissions.js includes sunshineRegiment
 • lib/views now includes default view and deleted view
 • deleted view shows all posts, with deleted posts flagged, sorted by deleted