### PR TITLE
Fixed bug in Vulcan login error messages

### DIFF
--- a/packages/vulcan-accounts/imports/ui/components/LoginForm.jsx
+++ b/packages/vulcan-accounts/imports/ui/components/LoginForm.jsx
@@ -640,7 +640,7 @@ export class AccountsLoginForm extends Tracker.Component {
         if (error) {
           console.log(error);
           const errorId = `accounts.error_${error.reason.toLowerCase().replace(/ /g, '_')}`;
-          this.showMessage(this.context.intl.formatMessage({id: errorId}) || error.reason || error.message || 'accounts.error_unknown', errorId, 'error');
+          this.showMessage(this.context.intl.formatMessage({id: errorId}) || error.reason || error.message || 'accounts.error_unknown', 'error');
         }
         else {
           loginResultCallback(() => this.state.onSignedInHook());
@@ -894,11 +894,11 @@ export class AccountsLoginForm extends Tracker.Component {
     if (messageId) {
       this.setState(({ messages = [] }) => {
         messages.push({
-          message: this.context.intl.formatMessage({id: messageId}),
+          message: this.context.intl.formatMessage({id: messageId, defaultMessage: messageId}),
           type,
           ...(field && { field }),
         });
-        return  { messages };
+        return { messages };
       });
       if (clearTimeout) {
         this.hideMessageTimout = setTimeout(() => {

--- a/packages/vulcan-i18n/lib/modules/provider.js
+++ b/packages/vulcan-i18n/lib/modules/provider.js
@@ -5,7 +5,7 @@ import { getSetting, Strings } from 'meteor/vulcan:lib';
 import { intlShape } from './shape.js';
 
 export default class IntlProvider extends Component{
-  
+
   constructor(){
     super();
     this.formatMessage = this.formatMessage.bind(this);
@@ -33,14 +33,14 @@ export default class IntlProvider extends Component{
         formatTime: this.formatStuff,
         formatRelative: this.formatStuff,
         formatNumber: this.formatStuff,
-        formatPlural: this.formatStuff, 
+        formatPlural: this.formatStuff,
         formatMessage: this.formatMessage,
         formatHTMLMessage: this.formatStuff,
         now: this.formatStuff,
       }
     };
   }
-  
+
   render(){
     return this.props.children;
   }


### PR DESCRIPTION
`this.showMessage(this.context.intl.formatMessage({id: errorId}) || error.reason || error.message || 'accounts.error_unknown', errorId, 'error');` is passing `'error'` as the third arg, which is `clearTimeout`, thus instantly clearing some errors. Removing the `errorId` parameter fixed it.