### PR TITLE
Indent blockquotes in firefox

### DIFF
--- a/packages/lesswrong/styles/_tufte.scss
+++ b/packages/lesswrong/styles/_tufte.scss
@@ -149,11 +149,9 @@
 
   blockquote { font-size: 1.1rem;
                padding: inherit;
-               margin:inherit;
-               border-left: none;
-               -webkit-margin-before: 1em;
-               -webkit-margin-after: 1em;
-               -webkit-margin-start: 40px; }
+               margin: inherit;
+               margin-left: 40px;
+               border-left: none; }
 
   blockquote p { /* width: 55%; */
                  margin-right: 40px;


### PR DESCRIPTION
Following this discussion: https://www.lesserwrong.com/posts/iuNSrBoX2W5qHCAAo/notes-from-an-apocalypse/uEK8ypFh2reoooNx7

Note that I've tested the CSS changes in the browser devtools, but I haven't done the whole "get the site working locally" thing I'd need to properly test this change. It's conceivable that the change I've made here won't propagate to the CSS in the way I expect.

The -webkit-margin-left property is intended to work with direction: rtl. Unless there's some way to set direction:rtl on LW (or plans to do it in future), it's easier to just use margin. Plus, when I set direction: rtl manually with the old style, the blockquotes get double-indented on the right due to a 40px margin-right on "blockquote p" elements. The new style has equal margin on both sides, in both directions, in both browsers.

The -webkit-margin-before/after properties seem to be having no effect in Chrome (1em is the value of those margins anyway), and there's no equivalent rule for firefox, so I thought it best to remove them.

So to summarize,

Before: ltr, blockquotes are left-and right-indented in Chrome, only right-indented on Firefox; visually hard to distinguish in firefox. rtl, blockquotes are double-right indented in chrome, right-indented in firefox, and left-indented in neither.

Now: blockquotes are indented equally on both sides, in both browsers, with both text directions.