### PR TITLE
Delete redundant .github/CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-Before starting on a new feature, please [check out the roadmap](https://trello.com/b/dwPR0LTz/vulcanjs-roadmap) and come check-in in the [Vulcan Slack channel](http://slack.telescopeapp.org/).
-
-Also, all PRs should be made to the `devel` branch, not `master`. 


### PR DESCRIPTION
This contributing guide doesn’t talk about the LessWrong 2.0 project, but about the template that this project is based on. There is already a newer `CONTRIBUTING.md` in the project root.

This version of `CONTRIBUTING.md`, in `.github`, is the one that GitHub links new contributors to when they visit the [Issues page](https://github.com/Discordius/Lesswrong2/issues).

You may want to also move the existing `CONTRIBUTING.md` into `.github/CONTRIBUTING.md`, if you prefer that file path.