### PR TITLE
Add X-Forwarded-For whitelist.

### DIFF
--- a/packages/lesswrong/lib/modules/connection_logs.js
+++ b/packages/lesswrong/lib/modules/connection_logs.js
@@ -1,6 +1,7 @@
 import LWEvents from '../collections/lwevents/collection.js';
 import { newMutation } from 'meteor/vulcan:core';
 import Users from 'meteor/vulcan:users';
+import { ForwardedWhitelist } from './forwarded_whitelist.js';
 
 const dummyUser = Users.findOne();
 
@@ -48,7 +49,7 @@ Accounts.onLogin((login) => {
     properties: {
       type: login.type,
       id: login.connection && login.connection.id,
-      ip: login.connection && login.connection.clientAddress
+      ip: login.connection && ForwardedWhitelist.getClientIP(login.connection)
     }
   }
   newMutation({

--- a/packages/lesswrong/lib/modules/forwarded_whitelist.js
+++ b/packages/lesswrong/lib/modules/forwarded_whitelist.js
@@ -4,16 +4,18 @@ import process from 'process';
 
 var whitelist = {};
 
-Object.values(getSetting("forwardedWhitelist")).forEach((hostname) => {
-  dns.resolve(hostname, "ANY", (err, records) => {
-    if(!err) {
-      records.forEach((rec) => {
-        whitelist[rec.address] = true;
-        console.log("Adding " + hostname + ": " + rec.address + " to whitelist.");
-      });
-    }
+if(getSetting("forwardedWhitelist")) {
+  Object.values(getSetting("forwardedWhitelist")).forEach((hostname) => {
+    dns.resolve(hostname, "ANY", (err, records) => {
+      if(!err) {
+        records.forEach((rec) => {
+          whitelist[rec.address] = true;
+          console.log("Adding " + hostname + ": " + rec.address + " to whitelist.");
+        });
+      }
+    });
   });
-});
+}
 
 export const ForwardedWhitelist = {
   getClientIP: (connection) => {

--- a/packages/lesswrong/lib/modules/forwarded_whitelist.js
+++ b/packages/lesswrong/lib/modules/forwarded_whitelist.js
@@ -1,0 +1,27 @@
+import { getSetting } from 'meteor/vulcan:core';
+import dns from 'dns';
+import process from 'process';
+
+var whitelist = {};
+
+Object.values(getSetting("forwardedWhitelist")).forEach((hostname) => {
+  dns.resolve(hostname, "ANY", (err, records) => {
+    if(!err) {
+      records.forEach((rec) => {
+        whitelist[rec.address] = true;
+        console.log("Adding " + hostname + ": " + rec.address + " to whitelist.");
+      });
+    }
+  });
+});
+
+export const ForwardedWhitelist = {
+  getClientIP: (connection) => {
+    if(whitelist[connection.clientAddress]) {
+      let forwarded = connection.httpHeaders["x-forwarded-for"].trim().split(/\s*,\s*/);
+      return forwarded[forwarded.length - (parseInt(process.env['HTTP_FORWARDED_COUNT']) || 0) - 1];
+    } else {
+      return connection.clientAddress;
+    }
+  }
+}


### PR DESCRIPTION
The X-Forwarded-For header contains a list of IP addresses, each representing the client IP address as seen by successive proxies the request has been forwarded through. Since it's trivial for a client to add false information to the beginning of this list, normally the client IP address is determined by looking at a fixed position starting from the end of the list, as controlled by the HTTP_FORWARDED_COUNT environment variable, which represents the number of reverse proxies or load balancers in front of the server.

This PR adds a whitelist which effectively increases HTTP_FORWARDED_COUNT by one for selected clients. The whitelist is configured by forwardedWhitelist in settings.json as an array of hostnames (NOT IP addresses), for example:

"forwardedWhitelist": ["host1.com", "host2.com"]

The hostnames are resolved on server startup and all IP addresses associated with them are added to the whitelist.

This is required for logging in through a third party frontend to work, otherwise a user could evade a ban by going to the third party frontend, and banning one user of the frontend would effectively ban everyone using it.