### PR TITLE
Add margin to text on mobile

### DIFF
--- a/packages/lesswrong/styles/_tufte.scss
+++ b/packages/lesswrong/styles/_tufte.scss
@@ -297,6 +297,7 @@ body {
                                                                      position: relative; }
                               label { cursor: pointer; }
                               div.table-wrapper, table { width: 85%; }
-                              img { width: 100%; } }
-
+                              img { width: 100%; }
+                              .content-body { margin: 0 15px }
+  }
 }

--- a/packages/lesswrong/styles/_tufte.scss
+++ b/packages/lesswrong/styles/_tufte.scss
@@ -298,6 +298,6 @@ body {
                               label { cursor: pointer; }
                               div.table-wrapper, table { width: 85%; }
                               img { width: 100%; }
-                              .content-body { margin: 0 15px }
+                              .content-body { margin: 0 5px }
   }
 }


### PR DESCRIPTION
# Description
The text of articles was right up to the edge of the screen on mobile which made text reading ever so slightly annoying. This will give the text some room to breath :)

# Screenshots
Before:
![image](https://user-images.githubusercontent.com/4751193/36637368-7ff5a66a-198f-11e8-8159-e4a8b021f44d.png)

After:
![image](https://user-images.githubusercontent.com/4751193/36637378-a920b6b0-198f-11e8-8710-5ac68d0755e9.png)

# Testing
I couldn't get the dev environment working so this is untested other than fiddling the css on the page.