### PR TITLE
Remember scroll location on page reload. Fixes #295

### DIFF
--- a/packages/lesswrong/lib/index.js
+++ b/packages/lesswrong/lib/index.js
@@ -113,6 +113,7 @@ import './legacy-redirects/views.js';
 import './helpers.js'
 import './routes.js';
 import './views.js';
+import './scrollRestoration.js';
 //
 // Closed Beta Stuff
 import './scripts/configuration.js';

--- a/packages/lesswrong/lib/scrollRestoration.js
+++ b/packages/lesswrong/lib/scrollRestoration.js
@@ -2,7 +2,8 @@ import { Meteor } from 'meteor/meteor';
 
 /* When refreshing the page, tell the browser to remember the scroll position.
  * Otherwise, users get scrolled to the top of the page.
- */ (See https://github.com/Discordius/Lesswrong2/issues/295#issuecomment-385866050)
+ */
+ // (See https://github.com/Discordius/Lesswrong2/issues/295#issuecomment-385866050)
 function rememberScrollPositionOnPageReload() {
   window.addEventListener('beforeunload', () => {
     if ('scrollRestoration' in window.history) {

--- a/packages/lesswrong/lib/scrollRestoration.js
+++ b/packages/lesswrong/lib/scrollRestoration.js
@@ -1,0 +1,20 @@
+import { Meteor } from 'meteor/meteor';
+
+/* When refreshing the page, tell the browser to remember the scroll position.
+ * Otherwise, users get scrolled to the top of the page.
+ */ (See https://github.com/Discordius/Lesswrong2/issues/295#issuecomment-385866050)
+function rememberScrollPositionOnPageReload() {
+  window.addEventListener('beforeunload', () => {
+    if ('scrollRestoration' in window.history) {
+      try {
+        window.history.scrollRestoration = 'auto';
+      } catch (e) {}
+    }
+  });
+}
+
+Meteor.startup(() => {
+  if (!Meteor.isServer) {
+    rememberScrollPositionOnPageReload();
+  }
+});


### PR DESCRIPTION
The fix here ended up being fairly simple.

When the page unloads, set scroll restoration to "auto". The next time LessWrong is loaded, it will use the browser's default scroll restoration feature. Then when the JavaScript app runs, it will switch to using "manual" scroll restoration.

This way it only uses "auto" scroll restoration on the first page load, before the single-page app is initialized.